### PR TITLE
Fix/option custom

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -316,7 +316,9 @@ def completetaxo(idlist, QUERY, OPTIONS):
     idlist = [i.split(".")[0] for i in idlist]
     ## retreive the taxonomy sending batches of TaxIds to efetch
     # number of TaxIds to be sent to the API at once
+    # above 60 make the parsing of the file more difficult see https://github.com/RaphaelHebert/nsdpy/pull/39
     retmax = 50
+
     count = len(idlist)
     if count % retmax == 0:
         nb = count // retmax

--- a/functions.py
+++ b/functions.py
@@ -316,7 +316,7 @@ def completetaxo(idlist, QUERY, OPTIONS):
     idlist = [i.split(".")[0] for i in idlist]
     ## retreive the taxonomy sending batches of TaxIds to efetch
     # number of TaxIds to be sent to the API at once
-    retmax = 100
+    retmax = 50
     count = len(idlist)
     if count % retmax == 0:
         nb = count // retmax
@@ -328,7 +328,6 @@ def completetaxo(idlist, QUERY, OPTIONS):
         retstart = x * retmax
         idsublist = idlist[retstart : (retstart + retmax)]
         idsublist = ",".join(idsublist)
-
         # parameters
         parameters = {
             "db": "taxonomy",
@@ -345,7 +344,6 @@ def completetaxo(idlist, QUERY, OPTIONS):
 
         ## analyse the results from efetch
         result = result.text.split("</Taxon>\n<Taxon>")
-
         for seq in result:
             dicttemp = {}
             try:
@@ -385,7 +383,6 @@ def completetaxo(idlist, QUERY, OPTIONS):
                 dicttemp["dispatch"] = dispatch(lineage, classif)
 
             data[TaxId] = dicttemp
-
     # comments
     if verb and verb > 0:
         print(f"number of taxids:\t{len(data.keys())}")

--- a/nsdpy.py
+++ b/nsdpy.py
@@ -1,4 +1,4 @@
-__version__ = "0.3.29-beta"
+__version__ = "0.3.30-beta"
 __author__ = "Raphael Hebert, Emese Meglecz"
 __email__ = "raphaelhebert18@gmail.com, emese.meglecz@imbe.fr"
 __license__ = "MIT"

--- a/nsdpy.py
+++ b/nsdpy.py
@@ -1,4 +1,4 @@
-__version__ = "0.3.30-beta"
+__version__ = "0.3.33-beta"
 __author__ = "Raphael Hebert, Emese Meglecz"
 __email__ = "raphaelhebert18@gmail.com, emese.meglecz@imbe.fr"
 __license__ = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nsdpy"
-version = "0.3.30-beta"
+version = "0.3.33-beta"
 description = "Automatize the download of DNA sequences from NCBI, sort them according to their taxonomy and filter them with a gene name (provided as a regular expression)"
 authors = ["RaphaelHebert <raphaelhebert18@gmail.com>", "Emese Meglecz <emese.meglecz@imbe.fr>"]
 include = ["functions.py", "constants.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nsdpy"
-version = "0.3.29-beta"
+version = "0.3.30-beta"
 description = "Automatize the download of DNA sequences from NCBI, sort them according to their taxonomy and filter them with a gene name (provided as a regular expression)"
 authors = ["RaphaelHebert <raphaelhebert18@gmail.com>", "Emese Meglecz <emese.meglecz@imbe.fr>"]
 include = ["functions.py", "constants.py"]


### PR DESCRIPTION
# PULL REQUEST REVIEW

**please take a moment to fill the PR to help the reviewer understand your work better**

## AUTHOR'S CHECKLIST

- [x] self reviewed code
- [ ] added or updated UT
- [ ] updated the documentation
- [ ] commented code
- [x] manually tested code

## COMMENTS

**please take a moment to briefly explain your work or provide useful info for the reviewer, feel free to add screenshots or videos**

this PR fix the completetaxo function:
when a call is made with efetch to the taxonomy db with more than 60 ids the returned file is a file where the taxa are separated with "</Taxon>\n<Taxon>" but every 60 taxa the tags at the end of the last taxon closes the file to open a new one. The result is returned in one concatenated file. So the split as it is done with </Taxon>\n<Taxon> will aglomerate two taxa and so loose track of one.
The fix for now is to lower the number of id per call to 50. 
Better split should be done to correct this behaving and keep the number of id per call to 100 in order to limit the number of call to efetch
